### PR TITLE
add docs for azure deployment

### DIFF
--- a/v1/content/getting-started/_index.md
+++ b/v1/content/getting-started/_index.md
@@ -24,6 +24,10 @@ Here is a [tutorial](./build-from-source) explaining how to build the ThingsDB s
 
 Want to use ThingsDB in Docker? Check out our [Docker guide](./docker).
 
+### Azure
+
+Want to quickly deploy a ThingsDB environment to Azure? Check out the [Azure guide](./azure.md).
+
 ### GKE (Google Kubernetes Engine)
 
 The following link will explain how to deploy ThingsDB in GKE (Google Kubernetes Engine):

--- a/v1/content/getting-started/azure.md
+++ b/v1/content/getting-started/azure.md
@@ -1,0 +1,56 @@
+---
+title: "Azure"
+weight: 5
+---
+
+A single-node ThingsDB enviroment can easily be deployed to Microsoft Azure using the [terraform-azurerm-thingsdb](https://github.com/rickmoonex/terraform-azurerm-thingsdb) module.
+
+## Usage
+
+> Due to rate limiting issues with Docker Hub when trying to pull the Caddy image. The input of container registry credentials is necessary.
+> This can be a credential for Docker Hub, or a private registry. In case of a private registry the caddy image can be changed with the `caddy_image` input.
+
+To get started with the module you can use the following snippet:
+
+```hcl
+resource "azurerm_resource_group" "rg" {
+    name = "thingsdb-rg"
+    location = "westeurope"
+}
+
+module "thingsdb" {
+  source  = "rickmoonex/thingsdb/azurerm"
+  version = "1.1.0"
+
+  name = "mythingsdbdev"
+  resource_group = azurerm_resource_group.rg
+
+  # Replace these with your own credentials as mentioned above.
+  registry_credential = {
+    username = "user"
+    password = "pass"
+    server = "server"
+  }
+}
+```
+
+### API
+
+To enable the HTTP/WebSocket API of ThingsDB we can add the following input to the module:
+
+```hcl
+http_api = {
+    # This enables the HTTP API
+    enable = true
+    # This enabled the WebSocket API
+    enable_websocket = true
+}
+```
+
+This will start a Caddy sidecar container and serve the API at the FQDN of the conatiner group. For example: `https://mythingsdb.westeurope.azurecontainer.io`. When the WebSocket API is enabled it can be reached at `wss://<fqdn>/ws`.
+
+To change the FQDN used in the Caddy config to your own domain name. Add the `proxy_dns_name` property to the `http_api` block.
+
+### Inputs
+
+For further details and supported inputs please refer to the [Terraform Registry](https://registry.terraform.io/modules/rickmoonex/thingsdb/azurerm/latest?tab=inputs)

--- a/v1/content/getting-started/configuration.md
+++ b/v1/content/getting-started/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: "Configuration"
-weight: 5
+weight: 6
 chapter: false
 ---
 

--- a/v1/content/getting-started/readiness-liveness.md
+++ b/v1/content/getting-started/readiness-liveness.md
@@ -1,6 +1,6 @@
 ---
 title: "Readiness and liveness"
-weight: 7
+weight: 8
 chapter: false
 ---
 

--- a/v1/content/getting-started/start-up-node.md
+++ b/v1/content/getting-started/start-up-node.md
@@ -1,6 +1,6 @@
 ---
 title: "Start up node"
-weight: 6
+weight: 7
 chapter: false
 ---
 


### PR DESCRIPTION
I created a Terraform module for deploying ThingsDB to Microsoft Azure Container Instance.

Thought I might be a good addition to the docs.